### PR TITLE
Implementation for EoD toggle and fixes for issues #38 and #36

### DIFF
--- a/aerosync_commands.py
+++ b/aerosync_commands.py
@@ -131,6 +131,14 @@ class game(app_commands.Group):
         scrape_playerlist(game)
         await interaction.response.send_message('Scraped playerlist for game {}.'.format(game))
 
+    # EoD Toggle command
+    @app_commands.command()
+    @app_commands.check(is_host)
+    @app_commands.describe(game='Available Games')
+    async def enable_near_eod(self, interaction: discord.Interaction, game: Literal['A', 'B', 'C']):
+        database.set_game_attr(game, "eod_toggle", True)
+        await interaction.response.send_message('Updated EoD toggle value for game {}.'.format(game))
+
 
 class update(app_commands.Group):
     #toggle updates on or off

--- a/pi_app.py
+++ b/pi_app.py
@@ -115,7 +115,7 @@ def job_eod():
                 database.set_game_attr(game, "update_interval", if_eod_autoupdate_length)  # update the interval
                 database.set_game_attr(game, "eod_toggle", False)
 
-            if is_currently_eod:  # If EoD is already toggled
+            else:  # If EoD is already toggled
                 current_game_toggle = now_epoch + eod_toggle_length
 
                 print(f"[@ {time_string}]: EoD toggle flag for game {game} extended.")

--- a/pi_app.py
+++ b/pi_app.py
@@ -40,15 +40,104 @@ def job_A():
         current_time = datetime.now()
         time_string = current_time.strftime("%Y-%m-%d %H:%M:%S")
 
+        if game == 'A':
+            current_game_log = update_time_log_A
+        elif game == 'B':
+            current_game_log = update_time_log_B
+        else:
+            current_game_log = update_time_log_C
+
         if database.get_game_attr(game, "update_toggle"):
+
             # get current time since epoch
-            if int(time.time()) > update_time_log_A + database.get_game_attr(game, "update_interval"):
+            if int(time.time()) > current_game_log + database.get_game_attr(game, "update_interval"):
                 print("updating game at " + str(time_string))
-                update_time_log_A = int(time.time())
+                current_game_log = int(time.time())
                 try_update(game)
+
         if database.get_game_attr(game, "update_now_requested"):
             print("manually updating game at " + str(time_string))
+            current_game_log = int(time.time())  # reset automatic update timer
             try_update(game)
+
+        # save value
+        if game == 'A':
+            update_time_log_A = current_game_log
+        elif game == 'B':
+            update_time_log_B = current_game_log
+        else:
+            update_time_log_C = current_game_log
+
+
+eod_toggle_until_A = None
+is_A_in_eod = False
+eod_toggle_until_B = None
+is_B_in_eod = False
+eod_toggle_until_C = None
+is_C_in_eod = False
+
+
+# Scheduler job for EoD toggle (temp vc auto update delay change)
+@scheduler.task('interval', id='check_toggle_and_run', seconds=10, misfire_grace_time=900)
+def job_eod():
+    global eod_toggle_until_A, is_A_in_eod
+    global eod_toggle_until_B, is_B_in_eod
+    global eod_toggle_until_C, is_C_in_eod
+
+    eod_toggle_length = (30 * 60)  # Currently, EoD toggle lasts for 30mins
+    default_autoupdate_length = (5 * 60)  # default waiting period before auto scrape
+    if_eod_autoupdate_length = 20  # 20 second autoupdate pause
+
+    for game in ['A', 'B', 'C']:
+        current_time = datetime.now()
+        now_epoch = time.time()
+        time_string = current_time.strftime("%Y-%m-%d %H:%M:%S")
+
+        if game == 'A':
+            current_game_toggle = eod_toggle_until_A
+            is_currently_eod = is_A_in_eod
+        elif game == 'B':
+            current_game_toggle = eod_toggle_until_B
+            is_currently_eod = is_B_in_eod
+        else:
+            current_game_toggle = eod_toggle_until_C
+            is_currently_eod = is_C_in_eod
+
+        database_response = database.get_game_attr(game, "eod_toggle")
+
+        # Check for the flag being set by the discord command
+        if database_response:
+            if not is_currently_eod:  # if eod toggle needs startup
+                current_game_toggle = now_epoch + eod_toggle_length  # add 30 mins
+                is_currently_eod = True
+                print(f"[@ {time_string}]: EoD toggle flag for game {game} detected, 30 minute timer begun.")
+
+                database.set_game_attr(game, "update_interval", if_eod_autoupdate_length)  # update the interval
+                database.set_game_attr(game, "eod_toggle", False)
+
+            if is_currently_eod:  # If EoD is already toggled
+                current_game_toggle = now_epoch + eod_toggle_length
+
+                print(f"[@ {time_string}]: EoD toggle flag for game {game} extended.")
+
+        elif database_response is None:  # eod_toggle needs to be created
+            database.set_game_attr(game, "eod_toggle", False)
+
+        # Check if the current EoD toggle has been active for >30min
+        if is_currently_eod and now_epoch > current_game_toggle:
+            database.set_game_attr(game, "update_interval", default_autoupdate_length)  # resume default
+            print(f"[@ {time_string}]: 30 mins passed for game {game}. Update interval reset.")
+
+        # remembering the game's values
+        if game == 'A':
+            eod_toggle_until_A = current_game_toggle
+            is_A_in_eod = is_currently_eod
+        elif game == 'B':
+            eod_toggle_until_B = current_game_toggle
+            is_B_in_eod = is_currently_eod
+        else:
+            eod_toggle_until_C = current_game_toggle
+            is_C_in_eod = is_currently_eod
 
 
 @app.route("/")

--- a/pi_app.py
+++ b/pi_app.py
@@ -20,6 +20,15 @@ update_time_log_A = 0
 update_time_log_B = 0
 update_time_log_C = 0
 
+
+# Global variables for the EoD toggle method
+eod_toggle_until_A = None
+is_A_in_eod = False
+eod_toggle_until_B = None
+is_B_in_eod = False
+eod_toggle_until_C = None
+is_C_in_eod = False
+
 def try_update(game):
     database.set_game_attr(game, "update_now_requested", "Updating now")
     try:
@@ -67,14 +76,6 @@ def job_A():
             update_time_log_B = current_game_log
         else:
             update_time_log_C = current_game_log
-
-
-eod_toggle_until_A = None
-is_A_in_eod = False
-eod_toggle_until_B = None
-is_B_in_eod = False
-eod_toggle_until_C = None
-is_C_in_eod = False
 
 
 # Scheduler job for EoD toggle (temp vc auto update delay change)


### PR DESCRIPTION
Changes to the codebase:

- Issue #40 has been implemented as instructed in the issue description. That is, there is now a discord command to toggle an "EoD" mode, where the bot will change it's automatic scraping behavior to have a delay of 20sec instead of the default 5 minutes for a length of 30 minutes. 
- Issue #38 has been fixed. 
- Issue #36 has been fixed.

Note: I was unable to find a database method to directly add a game attribute to the database. I believe this might be a mistake on my end, however, I believe adding one is an important update if not. 